### PR TITLE
Added Matlab dependency alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This code is based on torch. It has been tested on Ubuntu 14.04 LTS.
 
 Dependencies:
 * [Torch](https://github.com/torch/torch7) (with [matio-ffi](https://github.com/soumith/matio-ffi.torch) and [loadcaffe](https://github.com/szagoruyko/loadcaffe))
-* [Matlab](https://www.mathworks.com/)
+* [Matlab](https://www.mathworks.com/) or [Octave](https://www.gnu.org/software/octave/)
 
 CUDA backend:
 * [CUDA](https://developer.nvidia.com/cuda-downloads)
@@ -29,7 +29,7 @@ To generate all results (in ``examples/``) using the provided scripts, simply ru
 ```
 run('gen_laplacian/gen_laplacian.m')
 ```
-in Matlab and then
+in Matlab or Octave and then
 ```
 python gen_all.py
 ```


### PR DESCRIPTION
As per this issue here: https://github.com/luanfujun/deep-photo-styletransfer/issues/4

**Octave setup steps:** 

1. Install Octave:

`sudo apt-get install liboctave-dev`

2. Download and install the image package manually for Octave here: https://octave.sourceforge.io/image/ 

* Or install it with: 

`octave`

`pkg install -forge image`

3. Change the direction of slash on [lines 1-2 of `/gen_laplacian/gen_laplacian.m`](https://github.com/luanfujun/deep-photo-styletransfer/blob/master/gen_laplacian/gen_laplacian.m#L1-L2).

4. Then finally, run: 

`octave`

`octave:1> run('gen_laplacian/gen_laplacian.m')`

