### PR TITLE
Removed unused matio-ff dependency neuralstyle_seg.lua

### DIFF
--- a/neuralstyle_seg.lua
+++ b/neuralstyle_seg.lua
@@ -4,7 +4,6 @@ require 'image'
 require 'optim'
 
 require 'loadcaffe'
-require 'libcuda_utils'
 
 require 'cutorch'
 require 'cunn'

--- a/neuralstyle_seg.lua
+++ b/neuralstyle_seg.lua
@@ -9,7 +9,6 @@ require 'libcuda_utils'
 require 'cutorch'
 require 'cunn'
 
-local matio = require 'matio'
 local cmd = torch.CmdLine()
 
 -- Basic options


### PR DESCRIPTION
Looking at neuralstyle_seg.lua, I do not see a reason to include `local matio = require 'matio'`, as `matio` is not used. Matio is used in deepmatting_seg.lua, and not neuralstyle_seg.lua. 

This is in line with the fact that manual mask support does not need Matio for the automatic mask creation.

https://github.com/soumith/matio-ffi.torch