### PR TITLE
Added the Interactive Foreground Extraction tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Here are some automatic and manual tools for creating a segmentation mask for a 
 #### Manual:
 * [Photoshop Quick Selection Tool](https://helpx.adobe.com/photoshop/using/making-quick-selections.html)
 * [GIMP Selection Tool](https://docs.gimp.org/en/gimp-tools-selection.html)
+* [GIMP G'MIC Plug-in Interactive Foreground Extraction tool] http://gmic.eu/gimp.shtml)
 
 ## Examples
 Here are some results from our algorithm (from left to right are input, style and our output):

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Here are some automatic and manual tools for creating a segmentation mask for a 
 #### Manual:
 * [Photoshop Quick Selection Tool](https://helpx.adobe.com/photoshop/using/making-quick-selections.html)
 * [GIMP Selection Tool](https://docs.gimp.org/en/gimp-tools-selection.html)
-* [GIMP G'MIC Plug-in Interactive Foreground Extraction tool] http://gmic.eu/gimp.shtml)
+* [GIMP G'MIC Interactive Foreground Extraction tool](http://gmic.eu/gimp.shtml)
 
 ## Examples
 Here are some results from our algorithm (from left to right are input, style and our output):


### PR DESCRIPTION
The GIMP plug-in known as G'MIC has a really useful Foreground Extract tool. I have been using it to create detailed masks extremely quickly, without a lot of tedious and time consuming work. Basically you don't have to trace objects, and instead you put green dots on what you want to keep, and red dots on what you want to remove, and then it intelligently selects the entire objects that you wanted. 

In the GIMP menus, the path to the tool is as follows:

`Filters->G’MIC->Contours->Extract foreground [interactive].`


Sources talking about the improvements that this plug-in has over the default GIMP tools:

https://photography-by-nic.com/2015/05/24/experimenting-with-gmic-interactive-foreground-extraction-filter-for-gimp/

https://graphicdesign.stackexchange.com/questions/44776/using-gimp-to-extract-a-background-from-a-set-of-pictures

https://www.reddit.com/r/GIMP/comments/2xshsl/help_is_there_a_better_way_to_use_or_an/